### PR TITLE
Fix #10: Use correct title for "letter pool" setting

### DIFF
--- a/language/.en.json
+++ b/language/.en.json
@@ -46,8 +46,8 @@
           ]
         },
         {
-          "label": "Vertical downwards",
-          "description": "pool of letters from which the blanks to be filled",
+          "label": "Letter pool",
+          "description": "Select the pool of letters from which the blanks will be filled",
           "default": "abcdefghijklmnopqrstuvwxy",
           "regexp": {}
         },

--- a/semantics.json
+++ b/semantics.json
@@ -85,8 +85,8 @@
       {
         "name": "fillPool",
         "type": "text",
-        "label": "Vertical downwards",
-        "description": "pool of letters from which the blanks to be filled",
+        "label": "Letter pool",
+        "description": "Select the pool of letters from which the blanks will be filled",
         "default": "abcdefghijklmnopqrstuvwxyz",
         "regexp": {
           "pattern": "^[^\t\n .<>?;:\"'`!@#$%^&*()\\[\\]{}_+=|\\-]*$"


### PR DESCRIPTION
# Motivation / Problem

The label for the letter pool setting is incorrect.

# Description

Fix the title and clean up the description a bit, in both the language and semantics file.

Closes #10.