### PR TITLE
Fix: Missing letter Z in letter pool

### DIFF
--- a/language/.en.json
+++ b/language/.en.json
@@ -48,7 +48,7 @@
         {
           "label": "Vertical downwards",
           "description": "pool of letters from which the blanks to be filled",
-          "default": "abcdefghijklmnopqrstuvwxy",
+          "default": "abcdefghijklmnopqrstuvwxyz",
           "regexp": {}
         },
         {


### PR DESCRIPTION
# Motivation / Problem

In the language file, the default letter pool contains every letter except Z. In `semantics.json`, the pool includes the letter Z.

# Description

Add Z to the letter pool in the language file to match the semantics file.